### PR TITLE
chore(ci): force deploy actions to node24

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -34,6 +34,9 @@ on:
       - "*"
   delete:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     name: "Deploy (Action / Deno)"
@@ -41,7 +44,6 @@ jobs:
     permissions: write-all
     environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}


### PR DESCRIPTION
## Summary\n- force JavaScript-based actions in deploy workflow to run on Node 24\n- keep existing deploy behavior unchanged\n\n## Why\nGitHub now warns when JS actions execute on Node 20. This ensures daemon-pricing deploy runs on latest LTS immediately, even for upstream actions that still declare Node 20.\n\nRelates to ubiquity-os/ubiquity-os-kernel#320