### PR TITLE
chore(ci): force Deno install path in deploy workflow

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Generate manifest for deploy
         if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno x -A -y npm:@ubiquity-os/plugin-manifest-tool@latest
+        run: deno x -A -y --no-lock npm:@ubiquity-os/plugin-manifest-tool@latest
         env:
           SKIP_BOT_EVENTS: ${{ env.SKIP_BOT_EVENTS }}
           EXCLUDE_SUPPORTED_EVENTS: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}


### PR DESCRIPTION
## Summary
- replace Bun setup in deploy Deno path with Deno setup (denoland/setup-deno@v2)
- switch dependency install to deno install --node-modules-dir=auto --no-lock
- replace manifest generation from un x to Deno equivalent deno x -A -y

## Notes
- lockfile is intentionally not used in this workflow (--no-lock)
- ction-deploy-plugin still self-installs Bun internally, so callers do not need additional setup changes