### PR TITLE
fix: skip deep estimate for manual /time

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Time labels are created automatically from `/time <duration>` or from the issue-
 
 ### Deep time estimates (async)
 
-On issue creation and `/time`, the plugin also dispatches a background workflow that checks out the target repo and uses Codex to refine the estimate. It silently updates the time label if the last time label was set by a bot (issue-open) or always when `/time` triggered the run. The workflow routes Codex calls through `ai.ubq.fi` using the kernel attestation token, so no OpenAI API key is required.
+On issue creation and bare `/time`, the plugin also dispatches a background workflow that checks out the target repo and uses Codex to refine the estimate. `/time <duration>` only sets the time label manually and does not trigger the workflow. The workflow silently updates the time label if the last time label was set by a bot (issue-open) or when bare `/time` triggered the run. It routes Codex calls through `ai.ubq.fi` using the kernel attestation token, so no OpenAI API key is required.
 
 ## Running locally
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,6 +21,10 @@ function getExplicitTimeInput(context: Context): string {
   return body.replace(/^\s*\/time\b/i, "").trim();
 }
 
+function shouldDispatchDeepEstimateAfterTime(context: Context<"issue_comment.created">): boolean {
+  return !getExplicitTimeInput(context);
+}
+
 async function maybeDispatchDeepEstimate(context: Context, options: Parameters<typeof dispatchDeepEstimate>[1], message: string) {
   try {
     await dispatchDeepEstimate(context, options);
@@ -55,6 +59,22 @@ async function ensureTimeCommandAuthorized(context: Context<"issue_comment.creat
   return false;
 }
 
+async function maybeDispatchDeepEstimateAfterTime(context: Context<"issue_comment.created">) {
+  if (!shouldDispatchDeepEstimateAfterTime(context)) {
+    return;
+  }
+
+  await maybeDispatchDeepEstimate(
+    context,
+    {
+      trigger: "issue_comment.created",
+      forceOverride: true,
+      initiator: context.payload.sender?.login,
+    },
+    "Failed to dispatch deep time estimate after /time."
+  );
+}
+
 async function handleIssueCommentCreated(context: Context) {
   if (!isWorkerOrLocalEnvironment() || !isIssueCommentEvent(context)) {
     return;
@@ -66,17 +86,8 @@ async function handleIssueCommentCreated(context: Context) {
     return;
   }
 
-  const explicitDuration = getExplicitTimeInput(context);
   await time(context);
-  await maybeDispatchDeepEstimate(
-    context,
-    {
-      trigger: "issue_comment.created",
-      forceOverride: !explicitDuration,
-      initiator: context.payload.sender?.login,
-    },
-    "Failed to dispatch deep time estimate after /time."
-  );
+  await maybeDispatchDeepEstimateAfterTime(context);
 }
 
 async function handleIssuesOpened(context: Context) {
@@ -118,17 +129,8 @@ export async function handleCommand(context: Context) {
     if (!(await ensureTimeCommandAuthorized(context))) {
       return;
     }
-    const explicitDuration = getExplicitTimeInput(context);
     await time(context);
-    try {
-      await dispatchDeepEstimate(context, {
-        trigger: "issue_comment.created",
-        forceOverride: !explicitDuration,
-        initiator: context.payload.sender?.login,
-      });
-    } catch (err) {
-      logByStatus(context.logger, "Failed to dispatch deep time estimate after /time.", err);
-    }
+    await maybeDispatchDeepEstimateAfterTime(context);
   }
 }
 

--- a/tests/time-permissions.test.ts
+++ b/tests/time-permissions.test.ts
@@ -192,10 +192,11 @@ describe("/time command permissions", () => {
     expect(mockDispatchDeepEstimate).not.toHaveBeenCalled();
   });
 
-  it("allows the issue author to run /time", async () => {
+  it("allows the issue author to run bare /time and dispatches deep estimate", async () => {
     const { context, postComment, getCollaboratorPermissionLevel, checkMembershipForUser } = makeIssueCommentContext({
       sender: "author",
       issueAuthor: "author",
+      body: "/time",
     });
 
     await run(context);
@@ -205,13 +206,19 @@ describe("/time command permissions", () => {
     expect(checkMembershipForUser).not.toHaveBeenCalled();
     expect(mockTime).toHaveBeenCalledWith(context);
     expect(mockDispatchDeepEstimate).toHaveBeenCalledTimes(1);
+    expect(mockDispatchDeepEstimate).toHaveBeenCalledWith(context, {
+      trigger: "issue_comment.created",
+      forceOverride: true,
+      initiator: "author",
+    });
   });
 
-  it("allows an organization member to run /time", async () => {
+  it("allows an organization member to run /time with an explicit duration without deep estimate", async () => {
     const { context, postComment, getCollaboratorPermissionLevel, checkMembershipForUser, getMembershipForUser } = makeIssueCommentContext({
       sender: "member",
       orgLogin: "ubiquity-os-marketplace",
       isOrgMember: true,
+      body: "/time 2h",
     });
 
     await run(context);
@@ -227,15 +234,16 @@ describe("/time command permissions", () => {
     });
     expect(getCollaboratorPermissionLevel).not.toHaveBeenCalled();
     expect(mockTime).toHaveBeenCalledWith(context);
-    expect(mockDispatchDeepEstimate).toHaveBeenCalledTimes(1);
+    expect(mockDispatchDeepEstimate).not.toHaveBeenCalled();
   });
 
-  it("allows a billing manager to run /time", async () => {
+  it("allows a billing manager to run bare /time", async () => {
     const { context, postComment, getMembershipForUser } = makeIssueCommentContext({
       sender: "billing",
       orgLogin: "ubiquity-os-marketplace",
       isOrgMember: true,
       orgRole: "billing_manager",
+      body: "/time",
     });
 
     await run(context);
@@ -249,10 +257,17 @@ describe("/time command permissions", () => {
     expect(mockDispatchDeepEstimate).toHaveBeenCalledTimes(1);
   });
 
-  it("allows collaborators with write access to run /time", async () => {
+  it("skips deep estimate for parsed /time commands with an explicit duration", async () => {
     const { context, postComment, getCollaboratorPermissionLevel } = makeIssueCommentContext({
       sender: "collaborator",
       repoPermission: "write",
+      body: "/time",
+      command: {
+        name: "time",
+        parameters: {
+          duration: "2h",
+        },
+      },
     });
 
     await run(context);
@@ -264,7 +279,25 @@ describe("/time command permissions", () => {
       username: "collaborator",
     });
     expect(mockTime).toHaveBeenCalledWith(context);
+    expect(mockDispatchDeepEstimate).not.toHaveBeenCalled();
+  });
+
+  it("treats whitespace-only /time arguments as bare /time", async () => {
+    const { context } = makeIssueCommentContext({
+      sender: "collaborator",
+      repoPermission: "write",
+      body: "/time   ",
+    });
+
+    await run(context);
+
+    expect(mockTime).toHaveBeenCalledWith(context);
     expect(mockDispatchDeepEstimate).toHaveBeenCalledTimes(1);
+    expect(mockDispatchDeepEstimate).toHaveBeenCalledWith(context, {
+      trigger: "issue_comment.created",
+      forceOverride: true,
+      initiator: "collaborator",
+    });
   });
 
   it("ignores non-/time issue comments", async () => {

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -411,6 +411,7 @@ describe("time", () => {
       Promise.resolve([{ name: "Time: 5 Hours" }, { name: "Time: 15 Minutes" }, { name: "Time: 1 Week" }])
     );
     await time(context);
+    expect(mockCallLlm).not.toHaveBeenCalled();
     expect(mockAddLabelToIssue).toHaveBeenCalledWith(context, "Time: 5 Hours");
   });
 


### PR DESCRIPTION
## Summary
- only dispatch deep time estimates for bare `/time`
- skip deep estimate dispatch when `/time` is given an explicit duration
- add coverage for raw comment, parsed command, and whitespace-only `/time` flows

## Testing
- bun run test:jest -- tests/time.test.ts tests/time-permissions.test.ts

Closes #160