### PR TITLE
ci: migrate deploy workflow to new deno-deploy flow

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -70,17 +70,6 @@ jobs:
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
           echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
 
-      - name: Print deployment mode
-        shell: bash
-        run: |
-          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
-          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
-          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
-          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           pluginEntry: "./worker"
 
-      - uses: ubiquity-os/deno-deploy@main
+      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
         if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -170,6 +170,7 @@ jobs:
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
           token: ${{ secrets.DENO_2_DEPLOY_TOKEN || secrets.DENO_DEPLOY_TOKEN }}
+          organization: ubiquity-os
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
-      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
+      - uses: ubiquity-os/deno-deploy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -35,17 +35,13 @@ on:
   delete:
 
 jobs:
-  deploy:
-    name: "Deploy (Action / Deno)"
+  resolve:
+    name: "Resolve Source Ref"
     runs-on: ubuntu-latest
-    permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created' }}
-
+    outputs:
+      source_ref: ${{ steps.refs.outputs.source_ref }}
+      is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
+      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
     steps:
       - name: Resolve source ref
         id: refs
@@ -70,6 +66,18 @@ jobs:
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
           echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
 
+  deploy:
+    name: "Deploy (Action / Deno)"
+    runs-on: ubuntu-latest
+    needs: resolve
+    permissions: write-all
+    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created' }}
+    steps:
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
@@ -85,17 +93,17 @@ jobs:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out dist mirror branch
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         uses: actions/checkout@v6
         with:
-          ref: dist/${{ steps.refs.outputs.source_ref }}
+          ref: dist/${{ needs.resolve.outputs.source_ref }}
           path: dist_mirror_repo
 
       - name: Sync deep-estimate workflow to dist mirror
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         shell: bash
         env:
-          DIST_MIRROR_BRANCH: dist/${{ steps.refs.outputs.source_ref }}
+          DIST_MIRROR_BRANCH: dist/${{ needs.resolve.outputs.source_ref }}
           DIST_MIRROR_REPO_PATH: ${{ github.workspace }}/dist_mirror_repo
           SOURCE_WORKFLOW_PATH: ${{ github.workspace }}/.github/workflows/deep-estimate.yml
         run: |
@@ -124,35 +132,35 @@ jobs:
           git -C "$DIST_MIRROR_REPO_PATH" push origin "HEAD:$DIST_MIRROR_BRANCH"
 
       - name: Check out the repository
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         uses: actions/checkout@v6
 
       - name: Set up Deno
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
       - name: Install dependencies
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
         run: deno install --node-modules-dir=auto --no-lock
 
       - name: Generate manifest for deploy
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
         run: deno x -A -y --no-lock npm:@ubiquity-os/plugin-manifest-tool@latest
         env:
           SKIP_BOT_EVENTS: ${{ env.SKIP_BOT_EVENTS }}
           EXCLUDE_SUPPORTED_EVENTS: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          GITHUB_REF_NAME: ${{ steps.refs.outputs.source_ref }}
+          GITHUB_REF_NAME: ${{ needs.resolve.outputs.source_ref }}
 
       - uses: ubiquity-os/deno-plugin-adapter@main
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
         id: adapter
         with:
           pluginEntry: "./worker"
 
       - uses: ubiquity-os/deno-deploy@main
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -169,7 +169,7 @@ jobs:
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
-          token: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -35,13 +35,30 @@ on:
   delete:
 
 jobs:
-  resolve:
-    name: "Resolve Source Ref"
+  resolve-context:
+    name: "Resolve Context"
     runs-on: ubuntu-latest
+    permissions: read-all
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created' }}
     outputs:
       source_ref: ${{ steps.refs.outputs.source_ref }}
       is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
-      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
+      is_dist_ref: ${{ steps.refs.outputs.is_dist_ref }}
+      build_action_enabled: ${{ steps.config.outputs.build_action_enabled }}
+      deploy_deno_enabled: ${{ steps.config.outputs.deploy_deno_enabled }}
+      skip_bot_events: ${{ steps.config.outputs.skip_bot_events }}
+      exclude_supported_events: ${{ steps.config.outputs.exclude_supported_events }}
+      should_publish_action_artifact: ${{ steps.config.outputs.should_publish_action_artifact }}
+      should_run_deno: ${{ steps.config.outputs.should_run_deno }}
+      artifact_environment: ${{ steps.config.outputs.artifact_environment }}
+      deno_environment: ${{ steps.config.outputs.deno_environment }}
+      artifact_action: ${{ steps.config.outputs.artifact_action }}
+      deno_action: ${{ steps.config.outputs.deno_action }}
+
     steps:
       - name: Resolve source ref
         id: refs
@@ -57,60 +74,100 @@ jobs:
             is_tag_ref="true"
           fi
 
-          is_artifact_ref="false"
+          is_dist_ref="false"
           if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
+            is_dist_ref="true"
           fi
 
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+          echo "is_dist_ref=$is_dist_ref" >> "$GITHUB_OUTPUT"
 
-  deploy:
-    name: "Deploy (Action / Deno)"
+      - name: Resolve deployment settings
+        id: config
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.refs.outputs.source_ref }}
+          IS_TAG_REF: ${{ steps.refs.outputs.is_tag_ref }}
+          IS_DIST_REF: ${{ steps.refs.outputs.is_dist_ref }}
+        run: |
+          artifact_environment="development"
+          deno_environment="development"
+          if [[ "$SOURCE_REF" == "main" || "$SOURCE_REF" == "demo" ]]; then
+            artifact_environment="main"
+            deno_environment="main"
+          fi
+
+          artifact_action="publish"
+          deno_action="provision"
+          if [[ "${{ github.event_name }}" == "delete" ]]; then
+            artifact_action="delete"
+            deno_action="delete"
+          fi
+
+          should_publish_action_artifact="false"
+          if [[ "$BUILD_ACTION_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_publish_action_artifact="true"
+          fi
+
+          should_run_deno="false"
+          if [[ "$DEPLOY_DENO_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_run_deno="true"
+          fi
+
+          echo "build_action_enabled=$BUILD_ACTION_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "deploy_deno_enabled=$DEPLOY_DENO_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "skip_bot_events=$SKIP_BOT_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "exclude_supported_events=$EXCLUDE_SUPPORTED_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "artifact_environment=$artifact_environment" >> "$GITHUB_OUTPUT"
+          echo "deno_environment=$deno_environment" >> "$GITHUB_OUTPUT"
+          echo "artifact_action=$artifact_action" >> "$GITHUB_OUTPUT"
+          echo "deno_action=$deno_action" >> "$GITHUB_OUTPUT"
+          echo "should_publish_action_artifact=$should_publish_action_artifact" >> "$GITHUB_OUTPUT"
+          echo "should_run_deno=$should_run_deno" >> "$GITHUB_OUTPUT"
+
+  publish-action-artifact:
+    name: "Publish Action Artifact"
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_publish_action_artifact == 'true' }}
     runs-on: ubuntu-latest
-    needs: resolve
     permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created' }}
+    environment: ${{ needs.resolve-context.outputs.artifact_environment }}
+
     steps:
       - name: Publish action artifact branch
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
         with:
-          action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
+          action: ${{ needs.resolve-context.outputs.artifact_action }}
           treatAsEsm: true
           sourcemap: true
           pluginEntry: "${{ github.workspace }}/src/action.ts"
-          excludeSupportedEvents: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          skipBotEvents: ${{ env.SKIP_BOT_EVENTS }}
+          excludeSupportedEvents: ${{ needs.resolve-context.outputs.exclude_supported_events }}
+          skipBotEvents: ${{ needs.resolve-context.outputs.skip_bot_events }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - uses: actions/checkout@v6
+        if: ${{ needs.resolve-context.outputs.artifact_action != 'delete' }}
+
       - name: Check out dist mirror branch
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
+        if: ${{ needs.resolve-context.outputs.artifact_action != 'delete' }}
         uses: actions/checkout@v6
         with:
-          ref: dist/${{ needs.resolve.outputs.source_ref }}
+          ref: dist/${{ needs.resolve-context.outputs.source_ref }}
           path: dist_mirror_repo
 
       - name: Sync deep-estimate workflow to dist mirror
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' && github.event_name != 'delete' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
+        if: ${{ needs.resolve-context.outputs.artifact_action != 'delete' }}
         shell: bash
         env:
-          DIST_MIRROR_BRANCH: dist/${{ needs.resolve.outputs.source_ref }}
+          DIST_MIRROR_BRANCH: dist/${{ needs.resolve-context.outputs.source_ref }}
           DIST_MIRROR_REPO_PATH: ${{ github.workspace }}/dist_mirror_repo
           SOURCE_WORKFLOW_PATH: ${{ github.workspace }}/.github/workflows/deep-estimate.yml
         run: |
           set -euo pipefail
 
-          # github.workspace remains the source branch checkout for this deploy run.
-          # dist_mirror_repo is a second checkout of the published dist/<source> mirror.
           if [ ! -f "$SOURCE_WORKFLOW_PATH" ]; then
             echo "::notice::Skipping deep-estimate workflow sync because $SOURCE_WORKFLOW_PATH does not exist."
             exit 0
@@ -131,36 +188,19 @@ jobs:
           git -C "$DIST_MIRROR_REPO_PATH" commit -m "chore: [skip ci] sync deep-estimate workflow"
           git -C "$DIST_MIRROR_REPO_PATH" push origin "HEAD:$DIST_MIRROR_BRANCH"
 
-      - name: Check out the repository
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
-        uses: actions/checkout@v6
+  deploy-deno:
+    name: "Provision Deno App"
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_run_deno == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    environment: ${{ needs.resolve-context.outputs.deno_environment }}
 
-      - name: Set up Deno
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Install dependencies
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno install --node-modules-dir=auto --no-lock
-
-      - name: Generate manifest for deploy
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno x -A -y --no-lock npm:@ubiquity-os/plugin-manifest-tool@latest
-        env:
-          SKIP_BOT_EVENTS: ${{ env.SKIP_BOT_EVENTS }}
-          EXCLUDE_SUPPORTED_EVENTS: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          GITHUB_REF_NAME: ${{ needs.resolve.outputs.source_ref }}
-
-      - uses: ubiquity-os/deno-plugin-adapter@main
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        id: adapter
-        with:
-          pluginEntry: "./worker"
+    steps:
+      - uses: actions/checkout@v6
+        if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve.outputs.is_tag_ref != 'true' && needs.resolve.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
@@ -171,6 +211,6 @@ jobs:
         with:
           token: ${{ secrets.DENO_2_DEPLOY_TOKEN || secrets.DENO_DEPLOY_TOKEN }}
           organization: ubiquity-os
-          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          action: ${{ needs.resolve-context.outputs.deno_action }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
-          entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}
+          entrypoint: src/worker.ts

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -66,16 +66,9 @@ jobs:
             is_artifact_ref="true"
           fi
 
-          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
-            action_ref_branch="dist/${source_ref}"
-          else
-            action_ref_branch="${source_ref}"
-          fi
-
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
           echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
-          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
 
       - name: Print deployment mode
         shell: bash
@@ -87,7 +80,6 @@ jobs:
           echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
           echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
           echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-          echo "ACTION_REF=${ACTION_REF}"
 
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
@@ -178,13 +170,9 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
-          ACTION_REF: ${{ env.ACTION_REF }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
-          organization: ${{ secrets.DENO_ORG_NAME }}
+          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}
-          project_name: ${{ secrets.DENO_PROJECT_NAME }}
-          sourceRef: ${{ steps.refs.outputs.source_ref }}
-          artifactPrefix: dist/

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -169,7 +169,7 @@ jobs:
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
-          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN || secrets.DENO_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@octokit/auth-app": "^7.1.4",
         "@octokit/rest": "^22.0.1",
         "@sinclair/typebox": "0.34.41",
-        "@ubiquity-os/plugin-sdk": "^3.11.1",
+        "@ubiquity-os/plugin-sdk": "3.12.5",
         "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
         "decimal.js": "^10.4.3",
         "hono": "^4.11.7",
@@ -788,7 +788,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.52.0", "", { "dependencies": { "@typescript-eslint/types": "8.52.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ=="],
 
-    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.11.1", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-tYnt+Xh5WqufV3StUJVROlu5KzbBtSHc86302G2x/+CbyH2e52qA2hu77XbWqdwWDRJa1j82U3SIAw8s9efQxA=="],
+    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.12.5", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "ms": "^2.1.3", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-T1TAdD6rZDVrRELrEiQWM5bBRdzvFzMD+o6lthCahlGkvTOG3xxPHe8iXVnYrq60qnnMTrlUGm/uV9cIujZZ5A=="],
 
     "@ubiquity-os/ubiquity-os-logger": ["@ubiquity-os/ubiquity-os-logger@1.4.0", "", {}, "sha512-giybluPmu0sreEWi60t9X8NxC5d48X7oQAb9RjXR7wX/ZNYugbAaKgj0TYEqECvSVDqgzpKo7UNerh1UQBscGw=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@octokit/auth-app": "^7.1.4",
     "@octokit/rest": "^22.0.1",
     "@sinclair/typebox": "0.34.41",
-    "@ubiquity-os/plugin-sdk": "^3.11.1",
+    "@ubiquity-os/plugin-sdk": "3.12.5",
     "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
     "decimal.js": "^10.4.3",
     "hono": "^4.11.7",

--- a/src/handlers/check-modified-base-rate.ts
+++ b/src/handlers/check-modified-base-rate.ts
@@ -1,6 +1,6 @@
 import { CONFIG_FULL_PATH, CONFIG_ORG_REPO, DEV_CONFIG_FULL_PATH } from "@ubiquity-os/plugin-sdk/constants";
 import { ConfigurationHandler } from "@ubiquity-os/plugin-sdk/configuration";
-import manifest from "../../manifest.json";
+import manifest from "../../manifest.json" with { type: "json" };
 import { isDeepEqual } from "../shared/deep-equal";
 import { Context } from "../types/context";
 import { isPushEvent } from "../types/typeguards";

--- a/src/handlers/get-label-changes.ts
+++ b/src/handlers/get-label-changes.ts
@@ -1,6 +1,6 @@
 import { ConfigurationHandler } from "@ubiquity-os/plugin-sdk/configuration";
 import { CONFIG_FULL_PATH, CONFIG_ORG_REPO, DEV_CONFIG_FULL_PATH } from "@ubiquity-os/plugin-sdk/constants";
-import manifest from "../../manifest.json";
+import manifest from "../../manifest.json" with { type: "json" };
 import { isDeepEqual } from "../shared/deep-equal";
 import { Context } from "../types/context";
 import { isPushEvent } from "../types/typeguards";

--- a/src/handlers/global-config-update.ts
+++ b/src/handlers/global-config-update.ts
@@ -3,7 +3,7 @@ import { Value } from "@sinclair/typebox/value";
 import { ConfigurationHandler } from "@ubiquity-os/plugin-sdk/configuration";
 import { CONFIG_ORG_REPO } from "@ubiquity-os/plugin-sdk/constants";
 import { customOctokit } from "@ubiquity-os/plugin-sdk/octokit";
-import manifest from "../../manifest.json";
+import manifest from "../../manifest.json" with { type: "json" };
 import { isUserAdminOrBillingManager, listOrgRepos, listRepoIssues } from "../shared/issue";
 import { logByStatus } from "../shared/logging";
 import { COMMIT_MESSAGE } from "../types/constants";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,7 @@
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
 import { createPlugin, Options } from "@ubiquity-os/plugin-sdk";
-import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
+import { Manifest, resolveRuntimeManifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { customOctokit } from "@ubiquity-os/plugin-sdk/octokit";
 import { LOG_LEVEL, LogLevel } from "@ubiquity-os/ubiquity-os-logger";
 import type { ExecutionContext } from "hono";
@@ -12,6 +12,14 @@ import { Context, SupportedEvents } from "./types/context";
 import { Env, envSchema } from "./types/env";
 import { AssistivePricingSettings, pluginSettingsSchema } from "./types/plugin-input";
 import { normalizeMultilineSecret } from "./utils/secrets";
+
+function buildRuntimeManifest(request: Request) {
+  const runtimeManifest = resolveRuntimeManifest(manifest as Manifest);
+  return {
+    ...runtimeManifest,
+    homepage_url: new URL(request.url).origin,
+  };
+}
 
 async function startAction(context: Context, inputs: Record<string, unknown>) {
   const { payload, logger, env } = context;
@@ -75,6 +83,11 @@ async function startAction(context: Context, inputs: Record<string, unknown>) {
 
 export default {
   async fetch(request: Request, env: Record<string, unknown>, executionCtx?: ExecutionContext) {
+    const runtimeManifest = buildRuntimeManifest(request);
+    if (new URL(request.url).pathname === "/manifest.json") {
+      return Response.json(runtimeManifest);
+    }
+
     // It is important to clone the request because the body is read within createPlugin as well
     const responseClone = request.clone();
 
@@ -104,7 +117,7 @@ export default {
           }
         }
       },
-      manifest as Manifest,
+      runtimeManifest,
       {
         envSchema: envSchema as unknown as Options["envSchema"],
         settingsSchema: pluginSettingsSchema as unknown as Options["settingsSchema"],

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,7 +5,7 @@ import { Manifest, resolveRuntimeManifest } from "@ubiquity-os/plugin-sdk/manife
 import { customOctokit } from "@ubiquity-os/plugin-sdk/octokit";
 import { LOG_LEVEL, LogLevel } from "@ubiquity-os/ubiquity-os-logger";
 import type { ExecutionContext } from "hono";
-import manifest from "../manifest.json";
+import manifest from "../manifest.json" with { type: "json" };
 import { handleCommand, isLocalEnvironment, run } from "./run";
 import { Command } from "./types/command";
 import { Context, SupportedEvents } from "./types/context";

--- a/tests/__mocks__/handlers.ts
+++ b/tests/__mocks__/handlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { Buffer } from "node:buffer";
 import { CONFIG_FULL_PATH, DEV_CONFIG_FULL_PATH } from "@ubiquity-os/plugin-sdk/constants";
-import manifest from "../../manifest.json";
+import manifest from "../../manifest.json" with { type: "json" };
 import { getConfig } from "./config-store";
 import { db } from "./db";
 import issueTemplate from "./issue-template";

--- a/tests/__mocks__/helpers.ts
+++ b/tests/__mocks__/helpers.ts
@@ -4,7 +4,7 @@ import { resetConfig, setConfig } from "./config-store";
 import { db } from "./db";
 import issueTemplate from "./issue-template";
 import { STRINGS } from "./strings";
-import usersGet from "./users-get.json";
+import usersGet from "./users-get.json" with { type: "json" };
 
 const PLUGIN_KEY = "ubiquity-os-marketplace/daemon-pricing";
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -24,7 +24,7 @@ const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
   },
 });
 
-const url = "/";
+const url = "http://localhost";
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -9,8 +9,8 @@ import { AssistivePricingSettings, pluginSettingsSchema } from "../src/types/plu
 import workerFetch from "../src/worker";
 import { db } from "./__mocks__/db";
 import { server } from "./__mocks__/node";
-import issueCommented from "./__mocks__/requests/issue-comment-post.json";
-import usersGet from "./__mocks__/users-get.json";
+import issueCommented from "./__mocks__/requests/issue-comment-post.json" with { type: "json" };
+import usersGet from "./__mocks__/users-get.json" with { type: "json" };
 
 const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
   modulusLength: 2048,

--- a/tests/run.e2e.test.ts
+++ b/tests/run.e2e.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Context } from "../src/types/context";
+
+const mockCallLlm = jest.fn();
+const mockSanitizeLlmResponse = jest.fn((input: string) => input);
+
+jest.mock("@ubiquity-os/plugin-sdk", () => ({
+  callLlm: mockCallLlm,
+  sanitizeLlmResponse: mockSanitizeLlmResponse,
+}));
+
+const mockAddLabelToIssue = jest.fn();
+const mockRemoveLabelFromIssue = jest.fn();
+const mockCreateLabel = jest.fn();
+
+jest.mock("../src/shared/label", () => ({
+  addLabelToIssue: mockAddLabelToIssue,
+  removeLabelFromIssue: mockRemoveLabelFromIssue,
+  createLabel: mockCreateLabel,
+}));
+
+const mockDispatchDeepEstimate = jest.fn();
+jest.mock("../src/utils/deep-estimate-dispatch", () => ({
+  dispatchDeepEstimate: mockDispatchDeepEstimate,
+}));
+
+const mockSyncPriceLabelsToConfig = jest.fn();
+jest.mock("../src/handlers/sync-labels-to-config", () => ({
+  syncPriceLabelsToConfig: mockSyncPriceLabelsToConfig,
+}));
+
+const mockOnIssueOpenedUpdatePricing = jest.fn();
+jest.mock("../src/handlers/pricing-label", () => ({
+  onIssueOpenedUpdatePricing: mockOnIssueOpenedUpdatePricing,
+}));
+
+const logger = {
+  ok: jest.fn(),
+  warn: jest.fn((message: string) => new Error(message)),
+  info: jest.fn(),
+  error: jest.fn((message: string) => new Error(message)),
+  debug: jest.fn(),
+};
+
+let run: typeof import("../src/run").run;
+
+function makeOctokit() {
+  return {
+    rest: {
+      issues: {
+        addLabels: jest.fn(),
+        removeLabel: jest.fn(),
+        createLabel: jest.fn(),
+        listLabelsForRepo: jest.fn(),
+        listComments: jest.fn(),
+      },
+    },
+    paginate: jest.fn(() => Promise.resolve([{ name: "Time: 2 Hours" }])),
+  };
+}
+
+function baseContext() {
+  return {
+    logger,
+    authToken: "token",
+    env: {},
+    config: {
+      llmModel: {
+        reasoningEffort: "low",
+      },
+      labels: {
+        priority: [{ name: "Priority: 1 (Normal)" }],
+      },
+      basePriceMultiplier: 1,
+      shouldFundContributorClosedIssue: false,
+    },
+  };
+}
+
+function makeIssueOpenedContext(): Context<"issues.opened"> {
+  return {
+    ...baseContext(),
+    eventName: "issues.opened",
+    payload: {
+      action: "opened",
+      repository: {
+        owner: { login: "owner" },
+        name: "repo",
+        html_url: "https://github.com/owner/repo",
+      },
+      sender: { login: "author" },
+      issue: {
+        number: 1,
+        title: "Speed up caching",
+        body: "Cache API responses in memory.",
+        labels: [],
+        comments: 0,
+      },
+    },
+    octokit: makeOctokit(),
+  } as unknown as Context<"issues.opened">;
+}
+
+function makeTimeCommandContext(): Context<"issue_comment.created"> {
+  return {
+    ...baseContext(),
+    eventName: "issue_comment.created",
+    command: {
+      name: "time",
+      parameters: {},
+    },
+    payload: {
+      action: "created",
+      repository: {
+        owner: { login: "owner" },
+        name: "repo",
+        html_url: "https://github.com/owner/repo",
+      },
+      sender: { login: "author" },
+      issue: {
+        number: 2,
+        title: "Add telemetry",
+        body: "Record metrics for worker execution.",
+        user: { login: "author" },
+        labels: [],
+        comments: 0,
+      },
+      comment: {
+        id: 1,
+        body: "/time",
+        user: { login: "author", type: "User" },
+      },
+    },
+    octokit: makeOctokit(),
+  } as unknown as Context<"issue_comment.created">;
+}
+
+describe("run e2e time estimation", () => {
+  const envSnapshot = process.env.GITHUB_ACTIONS;
+
+  beforeAll(async () => {
+    ({ run } = await import("../src/run"));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (envSnapshot === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = envSnapshot;
+    }
+  });
+
+  it("handles issues.opened with auto-estimated time label", async () => {
+    process.env.GITHUB_ACTIONS = "true";
+    mockCallLlm.mockResolvedValue({
+      choices: [{ message: { content: "2 hours" } }],
+    });
+
+    const context = makeIssueOpenedContext();
+    await expect(run(context)).resolves.toEqual({ message: "OK" });
+    expect(mockCallLlm).toHaveBeenCalled();
+    expect(mockAddLabelToIssue).toHaveBeenCalledWith(context, "Time: 2 Hours");
+    expect(mockDispatchDeepEstimate).toHaveBeenCalled();
+  });
+
+  it("propagates errors when /time auto-estimation fails", async () => {
+    mockCallLlm.mockRejectedValue(new Error("LLM API error: 401 - unauthorized"));
+
+    const context = makeTimeCommandContext();
+    await expect(run(context)).rejects.toThrow("Failed to estimate time with LLM. Provide a duration like `/time 2 hours`.");
+    expect(mockDispatchDeepEstimate).not.toHaveBeenCalled();
+    expect(mockAddLabelToIssue).not.toHaveBeenCalled();
+  });
+});

--- a/tests/run.e2e.test.ts
+++ b/tests/run.e2e.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { Context } from "../src/types/context";
 
-const mockCallLlm = jest.fn();
-const mockSanitizeLlmResponse = jest.fn((input: string) => input);
+const mockCallLlm = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockSanitizeLlmResponse = jest.fn<(input: string) => string>((input: string) => input);
 
 jest.mock("@ubiquity-os/plugin-sdk", () => ({
   callLlm: mockCallLlm,


### PR DESCRIPTION
## Summary
- switch the deploy workflow to the new `provision` / `publish-manifest` / `delete` deno-deploy flow
- add the routed Deno manifest publication trigger
- replace the legacy deployctl-era inputs with the new Deno Deploy action inputs

## Notes
- this references `ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration` until that PR is merged
- this workflow now expects `DENO_2_DEPLOY_TOKEN`

Closes ubiquity-os/deno-deploy#17
Depends on ubiquity-os/deno-deploy#30